### PR TITLE
Ppc64le support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 branches:
-    only:
-        - master
-        - ppc64le_support
+  only:
+    - master
 language: ruby
 services:
-    - docker
+  - docker
 
 env:
   global:
-    - IMAGE=murilofv/jq
+    - IMAGE=imega/jq
     - NV=`curl --silent "https://raw.githubusercontent.com/alpinelinux/aports/master/main/jq/APKBUILD" | grep pkgver= | sed 's/pkgver=//g'`
 
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,47 @@
 branches:
     only:
         - master
+        - ppc64le_support
 language: ruby
 services:
     - docker
-script:
+
+env:
+  global:
+    - IMAGE=murilofv/jq
     - NV=`curl --silent "https://raw.githubusercontent.com/alpinelinux/aports/master/main/jq/APKBUILD" | grep pkgver= | sed 's/pkgver=//g'`
-    - RELEASE=0
-    - docker pull imega/jq:$NV || RELEASE=1
-    - make build TAG=$NV || exit 1
-after_success:
-    - |
-        [ "${RELEASE}" == "1" ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS TAG=$NV)
+
+stages:
+  - Arch-Build
+  - Manifest-Release
+
+jobs:
+  include:
+    - stage: Arch-Build
+      arch: amd64
+      os: linux
+      script:
+        - RELEASE=0
+        - docker pull $IMAGE:$NV-$TRAVIS_CPU_ARCH || RELEASE=1
+        - make build IMAGE=$IMAGE TAG=$NV || exit 1
+      after_success:
+        - "[ ${RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$NV)"
+
+    - stage: Arch-Build
+      arch: ppc64le
+      os: linux
+      script:
+        - RELEASE=0
+        - docker pull $IMAGE:$NV-$TRAVIS_CPU_ARCH || RELEASE=1
+        - make build IMAGE=$IMAGE TAG=$NV || exit 1
+      after_success:
+        - "[ ${RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$NV)"
+
+    - stage: Manifest-Release
+      arch: amd64
+      os: linux
+      script:
+        - export DOCKER_CLI_EXPERIMENTAL=enabled
+        - MANIFEST_RELEASE=0
+        - docker pull $IMAGE:$NV || MANIFEST_RELEASE=1
+        - "[ ${MANIFEST_RELEASE} == 1 ] && (make release-manifest DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$NV)"

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,34 @@
 BUILDER_VER = 1.9.0
 IMAGE=imega/jq
 TAG=latest
+ARCH=$(shell uname -m)
+
+ifeq ($(ARCH),x86_64)
+        ARCH=amd64
+endif
 
 build: buildfs test
-	@docker build -t $(IMAGE):$(TAG) .
-	@docker tag $(IMAGE):$(TAG) $(IMAGE):latest
+	@docker build -t $(IMAGE):$(TAG)-$(ARCH) .
+	@docker tag $(IMAGE):$(TAG)-$(ARCH) $(IMAGE):latest-$(ARCH)
 
 buildfs:
 	@docker run --rm \
 		-v $(CURDIR)/build:/build \
-		imega/base-builder:$(BUILDER_VER) \
+		murilofv/base-builder:$(BUILDER_VER) \
 		--packages="jq@edge-main"
 
 test:
 	@docker build -t $(IMAGE):test .
-	@echo '{"foo":10, "bar":200}' | docker run --rm -i imega/jq:test '.bar as $$x | .foo | . + $$x' | grep 210
+	@echo '{"foo":10, "bar":200}' | docker run --rm -i $(IMAGE):test '.bar as $$x | .foo | . + $$x' | grep 210
 
 release:
 	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
-	@docker push $(IMAGE):$(TAG)
-	@docker push $(IMAGE):latest
+	@docker push $(IMAGE):$(TAG)-$(ARCH)
+	@docker push $(IMAGE):latest-$(ARCH)
+
+release-manifest:
+	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
+	@docker manifest create $(IMAGE):$(TAG) $(IMAGE):$(TAG)-amd64 $(IMAGE):$(TAG)-ppc64le
+	@docker manifest create $(IMAGE):latest $(IMAGE):latest-amd64 $(IMAGE):latest-ppc64le
+	@docker manifest push $(IMAGE):$(TAG)
+	@docker manifest push $(IMAGE):latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILDER_VER = 1.9.1
+BUILDER_IMG = imega/base-builder:1.9.1
 IMAGE=imega/jq
 TAG=latest
 ARCH=$(shell uname -m)
@@ -14,7 +14,7 @@ build: buildfs test
 buildfs:
 	@docker run --rm \
 		-v $(CURDIR)/build:/build \
-		murilofv/base-builder:$(BUILDER_VER) \
+		$(BUILDER_IMG) \
 		--packages="jq@edge-main"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILDER_VER = 1.9.0
+BUILDER_VER = 1.9.1
 IMAGE=imega/jq
 TAG=latest
 ARCH=$(shell uname -m)


### PR DESCRIPTION
This commit add ppc64le support and makes travis build to both amd64 and
ppc64le architectures and generates a fat manifest that could be used as
a pointer in case it doesn't exist already in the repo.

Signed-off-by: Murilo Fossa Vicentini muvic@linux.ibm.com